### PR TITLE
Camelize item attributes for DB entry

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,11 @@ class ItemsController < ApplicationController
     @list = List.find_by(id: params[:list_id])
     @item = @list.items.new(name: params[:name].downcase.camelize, person: params[:person].downcase.camelize, department: params[:department].downcase.camelize)
 
-    if @item.save
+    if @item.valid?
+      @item.name = params[:name]
+      @item.person = params[:person]
+      @item.department = params[:department]
+      @item.save
       redirect_to list_path(@list), notice: "#{@item.name} added to the list for #{@item.person}"
     else
       redirect_to list_path(@list), notice: @item.errors.full_messages.join(", ")

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   
   def create
     @list = List.find_by(id: params[:list_id])
-    @item = @list.items.new(name: params[:name], person: params[:person], department: params[:department])
+    @item = @list.items.new(name: params[:name].downcase.camelize, person: params[:person].downcase.camelize, department: params[:department].downcase.camelize)
 
     if @item.save
       redirect_to list_path(@list), notice: "#{@item.name} added to the list for #{@item.person}"

--- a/app/helpers/lists_helper.rb
+++ b/app/helpers/lists_helper.rb
@@ -9,8 +9,8 @@ module ListsHelper
       "aria-controls" => list.id 
     }
     link_to("#list-#{list.id}", options) do
-      list_name = content_tag :div, list.name, class: "me-auto"
-      item_count = content_tag :span, list.items.count, class: "badge bg-primary rounded-pill"
+      list_name = content_tag :div, list.name, class: "me-auto list-name"
+      item_count = content_tag :span, list.items.count, class: "badge bg-primary rounded-pill item-count"
 
       list_name + item_count
     end

--- a/app/views/lists/_items_table.html.erb
+++ b/app/views/lists/_items_table.html.erb
@@ -11,7 +11,7 @@
   </thead>
   <tbody>
     <% list.items.each_with_index do |item, index| %>
-      <tr class="<%= item.bought ? "item-bought" : "" %>">
+      <tr class="items-table-item <%= item.bought ? "item-bought" : "" %>">
         <th scope="row"><%= index + 1 %></th>
         <td>
           <%= item.name %>

--- a/app/views/lists/_lists.html.erb
+++ b/app/views/lists/_lists.html.erb
@@ -11,8 +11,8 @@
   <div class="col-8">
     <div class="tab-content" id="nav-tabContent">
       <% current_user.lists.each_with_index do |list, index| %>
-        <%= tag.div class: "tab-pane fade show #{index == 0 ? 'active' : ''}", id: "list-#{list.id}" do %>
-          <h3>Items <%= link_to image_tag("edit_icon.png", width: 16), edit_list_path(list) %></h3>
+        <%= tag.div class: "shopping-list tab-pane fade show #{index == 0 ? 'active' : ''}", id: "list-#{list.id}" do %>
+          <h3>Items <%= link_to image_tag("edit_icon.png", width: 16), edit_list_path(list), class: "edit-list", id: "edit-list-#{list.id}" %></h3>
           <%= render "lists/items_table", list: list, index: index %>
         <% end %>
       <% end %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,18 @@
 version: "3.6"
 services:
     selenium:
-        image: selenium/standalone-chrome
+        image: selenium/hub
+        container_name: shoppinglist-selenium
         ports:
             - 4444:4444
+        environment:
+            GRID_MAX_SESSION: 10
+    chrome:
+        image: selenium/node-chrome
+        depends_on: 
+            - selenium
+        environment:
+            HUB_HOST: shoppinglist-selenium
+            NODE_MAX_INSTANCES: 5
+            NODE_MAX_SESSION: 5
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,23 @@ services:
             - 4444:4444
         environment:
             GRID_MAX_SESSION: 10
+        healthcheck:
+            test: ["CMD", "wget", "--spider", "http://localhost:4444/grid/api/proxy"] 
+            interval: 10s
+            timeout: 5s
+            retries: 3
     chrome:
         image: selenium/node-chrome
+        scale: 4
         depends_on: 
             - selenium
         environment:
             HUB_HOST: shoppinglist-selenium
             NODE_MAX_INSTANCES: 5
             NODE_MAX_SESSION: 5
+        healthcheck:
+            test: ["CMD", "wget", "--spider", "http://localhost:5555"]
+            interval: 10s
+            timeout: 5s
+            retries: 3
     

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -11,6 +11,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def setup
     Capybara.server_host = "0.0.0.0"
     Capybara.server = :puma, { Threads: "1:1" }
+    Capybara.always_include_port = true
     Capybara.app_host = "http://host.docker.internal:#{Capybara.current_session.server.port}"
     super
   end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,7 +4,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [1600, 1080], options: {
     url: "http://localhost:4444/wd/hub",
     desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(
-      chromeOptions: { args: %w[headless window-size=1600x1080 disable-gpu no-sandbox disable-dev-shm-usage] },
+      chromeOptions: { args: %w[headless window-size=1600x1080 no-sandbox disable-dev-shm-usage] },
     )
   }
 

--- a/test/system/items_test.rb
+++ b/test/system/items_test.rb
@@ -22,8 +22,8 @@ class ItemsTest < ApplicationSystemTestCase
     fill_in("Person:", with: "Brian")
     fill_in("Department:", with: "Produce")
     click_on "Add Item"
-    assert_selector ".the-list .list-item", count: 1
-    within ".the-list" do
+    assert_selector ".items-table-item", count: 1
+    within ".items-table-item" do
       assert_text "Bananas"
     end
   end
@@ -69,6 +69,20 @@ class ItemsTest < ApplicationSystemTestCase
     create_previous_shopping_list! user
     list = user.lists.create(name: "Shopping Place")
     visit list_path(list)
+    assert_selector "#item_department_datalist_options option", count: 2, visible: false
+    assert_selector "#item_department_datalist_options option", text: "Produce", visible: false
+    assert_selector "#item_department_datalist_options option", text: "Alcohol", visible: false
+  end
+
+  test "logged in user cannot add item when name finds a case insensitive match" do
+    login!
+    user = User.find_by(uid: "31415")
+    create_previous_shopping_list! user
+    list = user.lists.create(name: "Shopping Place")
+    visit list_path(list)
+    fill_in("Item name:", with: "BaNaNas")
+    fill_in("Person:", with: "Brian")
+    fill_in("Department:", with: "Produce")
     assert_selector "#item_department_datalist_options option", count: 2, visible: false
     assert_selector "#item_department_datalist_options option", text: "Produce", visible: false
     assert_selector "#item_department_datalist_options option", text: "Alcohol", visible: false

--- a/test/system/lists_test.rb
+++ b/test/system/lists_test.rb
@@ -31,10 +31,10 @@ class ListsTest < ApplicationSystemTestCase
     list = user.lists.create(name: "Shopping Place")
     list.items.create(name: "Bananas", person: "Person", department: "Produce")
     visit root_path
-    assert_selector ".shopping-list", count: 1
-    assert_css ".shopping-list .card-title", text: "Shopping Place"
-    within ".shopping-list .item-count" do
-      assert_text "Items: 1"
+    assert_selector ".items-table-item", count: 1
+    assert_css ".list-group-item .list-name", text: "Shopping Place"
+    within "#list-#{list.id}-list .item-count" do
+      assert_text "1"
     end
   end
 
@@ -45,9 +45,7 @@ class ListsTest < ApplicationSystemTestCase
     list.items.create(name: "Bananas", person: "Person", department: "Produce")
     visit root_path
     assert_selector ".shopping-list", count: 1
-    within ".shopping-list" do
-      click_on "Edit List"
-    end
+    click_link("edit-list-#{list.id}")
   end
 
   test "logged in user can delete a list" do
@@ -56,10 +54,8 @@ class ListsTest < ApplicationSystemTestCase
     list = user.lists.create(name: "Shopping Place")
     list.items.create(name: "Bananas", person: "Person", department: "Produce")
     visit root_path
-    assert_selector ".shopping-list", count: 1
-    within ".shopping-list" do
-      click_on "Edit List"
-    end
+    assert_selector ".items-table-item", count: 1
+    click_link("edit-list-#{list.id}")
     accept_confirm do
       click_link 'Delete List'
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require "rails/test_help"
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+  #parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require "rails/test_help"
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-  #parallelize(workers: :number_of_processors)
+  parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
- Change how item attributes are entered in the DB.  For cleanliness and uniformity, all item attribute entries will be entered in DB in camel-case (lower case is done first to standardize entry so camelize can be applied correctly).

Resolve issue #26 

![Capture](https://user-images.githubusercontent.com/74803363/115450199-3b53e700-a1e1-11eb-9bb6-4d799a6db5d4.PNG)
