### PR TITLE
Fix when no User in the database on first viewing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < ActionController::Base
   private
  
   def current_user
-    @current_user ||= User.find(session[:user_id]) if session[:user_id]
+    if User.count > 0
+      @current_user ||= User.find(session[:user_id]) if session[:user_id]
+    end
   end
 end


### PR DESCRIPTION
When there is no `User`'s in the database `current_user` was not being set.  Validation check for more than one `User` in database fixes this issue.