### PR TITLE
move lists to above item table

### DIFF
--- a/app/views/lists/_lists.html.erb
+++ b/app/views/lists/_lists.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-4">
+  <div class="col-8 offset-2" >
     <h3>Lists</h3>
     <div class="list-group" id="list-tab" role="tablist">
       <% current_user.lists.each_with_index do |list, index| %>
@@ -7,7 +7,8 @@
       <% end %>
     </div>
   </div>
-
+</div>
+<div class="row mt-4">
   <div class="col-8">
     <div class="tab-content" id="nav-tabContent">
       <%= react_component("items/PreviousDatalists", { previous_item_data: @previous_item_data })%>


### PR DESCRIPTION
Moved the lists selector section on the root page to it's own row above the items table.  This way, mobile users can see more of the items table.

Resolves Issue #32
** #36 STILL NEEDS TO BE COMPLETED **

PC:
![Capture](https://user-images.githubusercontent.com/74803363/117903409-1bba5680-b295-11eb-93df-1ebdd46f41a2.PNG)

MOBILE (iPhone 6/7/8):
![Capture](https://user-images.githubusercontent.com/74803363/117903528-54f2c680-b295-11eb-9f4d-dd8dadd261be.PNG)