### PR TITLE
Remove all bought items button

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,8 @@ class ItemsController < ApplicationController
     if @item = @list.items.find_by(name: params[:name], person: params[:person])
       result = @item.add_back_to_list
     else
-      result = @list.add_item(params)
+      @item = @list.add_item(params)
+      result = @item.valid?
     end
 
     if result

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -32,4 +32,15 @@ class ListsController < ApplicationController
       redirect_back(fallback_location: root_path, notice: "List not found")
     end
   end
+
+  def remove_bought
+    if @list = current_user.lists.find_by(id: params[:id])
+      @list.items.active.bought.each do |item|
+        item.remove_from_list
+      end
+      render json: { message: "Bought items removed" }
+    else
+      render json: { error: "List not found" }, status: 404
+    end
+ end
 end

--- a/app/helpers/lists_helper.rb
+++ b/app/helpers/lists_helper.rb
@@ -10,7 +10,7 @@ module ListsHelper
     }
     link_to("#list-#{list.id}", options) do
       list_name = content_tag :div, list.name, class: "me-auto list-name"
-      item_count = content_tag :span, list.items.count, class: "badge bg-primary rounded-pill item-count"
+      item_count = content_tag :span, list.items.active.count, class: "badge bg-primary rounded-pill item-count"
 
       list_name + item_count
     end

--- a/app/javascript/components/items/Table.js
+++ b/app/javascript/components/items/Table.js
@@ -56,7 +56,6 @@ const ItemRow = (props) => {
       <td><EditableField id={item.id} field="person" text={item.person} csrf={props.csrf} /></td>
       <td><EditableField id={item.id} field="department" text={item.department} csrf={props.csrf} /></td>
       <th scope="row"><QuantityController item={item} quantity={item.quantity} csrf={props.csrf}/></th>
-      {/* <td><button className="btn btn-danger btn-sm" onClick={() => props.removeItem(item)}>Remove</button></td> */}
     </tr>
   );
 };

--- a/app/javascript/components/items/Table.js
+++ b/app/javascript/components/items/Table.js
@@ -51,12 +51,12 @@ const ItemRow = (props) => {
 
   return (
     <tr className={rowClasses}>
-      <th scope="row"><QuantityController item={item} quantity={item.quantity} csrf={props.csrf}/></th>
+      <td><input type="checkbox" value="1" checked={checked} id={checkboxId} onChange={() => props.toggleBought(item)} /></td>
       <td><EditableField id={item.id} field="name" text={item.name} csrf={props.csrf} /></td>
       <td><EditableField id={item.id} field="person" text={item.person} csrf={props.csrf} /></td>
       <td><EditableField id={item.id} field="department" text={item.department} csrf={props.csrf} /></td>
-      <td><button className="btn btn-danger btn-sm" onClick={() => props.removeItem(item)}>Remove</button></td>
-      <td><input type="checkbox" value="1" checked={checked} id={checkboxId} onChange={() => props.toggleBought(item)} /></td>
+      <th scope="row"><QuantityController item={item} quantity={item.quantity} csrf={props.csrf}/></th>
+      {/* <td><button className="btn btn-danger btn-sm" onClick={() => props.removeItem(item)}>Remove</button></td> */}
     </tr>
   );
 };
@@ -71,9 +71,9 @@ const Table = (props) => {
     return sortConfig.key === name ? sortConfig.direction : undefined;
   };
   const handleSubmit = (e) => {
-    const nameField = e.target.closest("tr").querySelector("input[name=itemNameField");
-    const personField = e.target.closest("tr").querySelector("input[name=itemPersonField");
-    const departmentField = e.target.closest("tr").querySelector("input[name=itemDepartmentField");
+    const nameField = e.target.closest("tr").querySelector("input[name=itemNameField]");
+    const personField = e.target.closest("tr").querySelector("input[name=itemPersonField]");
+    const departmentField = e.target.closest("tr").querySelector("input[name=itemDepartmentField]");
     const data = {
       list_id: props.id,
       name: nameField.value,
@@ -99,6 +99,25 @@ const Table = (props) => {
       personField.value = "";
       departmentField.value = "";
     });
+  }
+
+  const handleRemoveBought = () => {
+    fetch("/lists/" + props.id + "/remove_bought", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "X-CSRF-Token": props.csrf,
+      }
+    }).then(response => {
+      for (var idx = items.length - 1; idx >= 0; idx--) {
+        if(items[idx].bought) {
+          items.splice(items[idx], 1);
+        }
+      }
+
+      requestSort(sortConfig.key, sortConfig.direction);
+    });
     
   }
 
@@ -117,7 +136,7 @@ const Table = (props) => {
     }).then(response => {
       requestSort(sortConfig.key, sortConfig.direction);
     });
-  };
+  }
 
   const removeItem = (item) => {
     items.splice(items.indexOf(item), 1)
@@ -138,6 +157,15 @@ const Table = (props) => {
       <table className="table items-table">
         <thead>
           <tr>
+            <th>
+              <button
+                type="button"
+                onClick={() => requestSort("bought")}
+                className={"btn btn-primary btn-sm " + getClassNamesFor("bought")}
+              >
+                Bought
+              </button>
+            </th>
             <th>
               <button
                 type="button"
@@ -174,16 +202,6 @@ const Table = (props) => {
                 Department
               </button>
             </th>
-            <th></th>
-            <th>
-              <button
-                type="button"
-                onClick={() => requestSort("bought")}
-                className={"btn btn-primary btn-sm " + getClassNamesFor("bought")}
-              >
-                Bought
-              </button>
-            </th>
           </tr>
         </thead>
         <tbody>
@@ -193,7 +211,9 @@ const Table = (props) => {
         </tbody>
         <tfoot>
         <tr className='items-table-item'>
-          <th scope="row">New Item</th>
+            <td>
+              <button className="btn btn-warning btn-sm" onClick={handleRemoveBought}>Remove Bought</button>
+            </td>
             <td>
               <input name="itemNameField" placeholder="Item Name" list="item_name_datalist_options"/>
             </td>
@@ -204,11 +224,9 @@ const Table = (props) => {
               <input name="itemDepartmentField" placeholder="Department Name" list="item_department_datalist_options"/>
             </td>
             <td>
-              <button className="btn btn-primary btn-sm" onClick={handleSubmit}>Add Item</button>
+              <button className="btn btn-success btn-sm" onClick={handleSubmit}>Add Item</button>
             </td>
-            <td>
-            {/* <button className="btn btn-danger btn-sm" onClick={() => console.log("TODO")}>Remove Bought</button> */}
-            </td>
+            
           </tr>
         </tfoot>
       </table>

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,6 +23,6 @@ class Item < ApplicationRecord
   end
 
   def add_back_to_list
-    update(quantity: 1, deleted_at: nil)
+    update(quantity: 1, deleted_at: nil, bought: false)
   end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -4,6 +4,9 @@ class List < ApplicationRecord
     def active
       where(deleted_at: nil)
     end
+    def bought
+      where(bought: true)
+    end
   end
 
   validates :name, length: { minimum: 1 }
@@ -20,9 +23,9 @@ class List < ApplicationRecord
       item.name = params[:name]
       item.person = params[:person]
       item.department = params[:department]
-      return item.save
-    else
-      return false
+      item.save
     end
+
+    item
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   get "/auth/:provider/callback" => "sessions#create"
   get "/logout" => "sessions#destroy", :as => :logout
 
-  resources :lists
+  resources :lists do
+    post :remove_bought, on: :member
+  end
   resources :items do
     post :remove, on: :member
   end

--- a/test/controllers/lists_controller_test.rb
+++ b/test/controllers/lists_controller_test.rb
@@ -1,9 +1,6 @@
 require "test_helper"
 
 class ListsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
   setup do
     List.destroy_all
     Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
@@ -89,5 +86,22 @@ class ListsControllerTest < ActionDispatch::IntegrationTest
     delete list_path(list)
     assert_redirected_to root_path
     assert_equal "You must be signed in to do that.", flash[:notice]
+  end
+
+  test "bought items are removed from a list" do
+    post "/auth/google_oauth2"
+    follow_redirect!
+    list = User.last.lists.create(name: "Shopping Place")
+    list.items.create(
+      list_id: 1,
+      name: "item",
+      person: "person",
+      department: "department",
+      bought: true,
+      quantity: 0
+    )
+    assert_nil list.items.last.deleted_at
+    post "/lists/1/remove_bought"
+    refute_nil list.items.last.deleted_at
   end
 end


### PR DESCRIPTION
- Reorganized the columns in the list table. This will allow mobile users to see the name of the item they are marking as bought more easily.
- Implemented bulk item removal (soft delete) functionality for lists:  When an item or items are marked as bought, there is now a button to remove (soft delete) all of those items from the given list.  ( Resolves Issue: #39 )
- Fixed an newly discovered bug when adding new items to a list. Items that were previously in the list were not being added correctly back to a list.
- Added unit test for `remove_bought` method


Co-authored-by: Andrew Nordman <cadwallion@github.com>


![Capture](https://user-images.githubusercontent.com/74803363/121271890-44307300-c88a-11eb-961f-85fe5c62d52c.PNG)