### PR TITLE
migration: change ids from string to integer

### DIFF
--- a/db/migrate/20210621173151_change_id_types.rb
+++ b/db/migrate/20210621173151_change_id_types.rb
@@ -1,0 +1,11 @@
+class ChangeIdTypes < ActiveRecord::Migration[6.1]
+  def up
+    change_column :shared_lists, :user_id, :integer
+    change_column :shared_lists, :list_id, :integer
+  end
+
+  def down
+    change_column :shared_lists, :user_id, :string
+    change_column :shared_lists, :list_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_16_225059) do
+ActiveRecord::Schema.define(version: 2021_06_21_173151) do
 
   create_table "items", force: :cascade do |t|
     t.integer "list_id", null: false
@@ -35,8 +35,8 @@ ActiveRecord::Schema.define(version: 2021_06_16_225059) do
   end
 
   create_table "shared_lists", force: :cascade do |t|
-    t.string "user_id"
-    t.string "list_id"
+    t.integer "user_id"
+    t.integer "list_id"
     t.boolean "active"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
Migration to change both the `user_id` and `list_id` from type :string to type :integer.

This fixes an issue with Postgres in prod stopping the app from working (Postgres could not compare string id's to integer id's from two different models).