### PR TITLE
Add item count badge to `ListEntry`

### DIFF
--- a/app/javascript/components/lists/ListEntry.js
+++ b/app/javascript/components/lists/ListEntry.js
@@ -9,10 +9,11 @@ const ListEntry = (props) => {
   const ariaControls = "list-" + list.id;
   const id = ariaControls + "-list";
   const href = "#list-" + list.id;
+  const badgeItemCount = (list.unbought_count) + "/" + (list.item_count);
 
   return (
     <React.Fragment>
-      <a 
+      <a
         key={list.id}
         className={className}
         id={id}
@@ -22,6 +23,9 @@ const ListEntry = (props) => {
         aria-controls={ariaControls}
         >
         <span className="p-0 m-0 flex-grow-1 me-auto list-name">{list.name}</span>
+        <span className="badge bg-primary rounded-pill item-count">
+          <span className="align-middle">{badgeItemCount}</span>
+        </span>
         <ListGroupButtons key={list.id} list={list} csrf={csrf} setState={props.handleStateChange} />
       </a>
     </React.Fragment>

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -8,6 +8,9 @@ class List < ApplicationRecord
     def bought
       where(bought: true)
     end
+    def unbought
+      where(bought: false)
+    end
   end
   validates :name, length: { minimum: 1 }
   validates :name, uniqueness: true;
@@ -28,5 +31,15 @@ class List < ApplicationRecord
     end
 
     item
+  end
+
+  def as_json(*)
+    super({
+      only: [:id, :name],
+      include: :items
+      }).merge({
+        unbought_count: items.unbought.count,
+        item_count: items.active.count
+      })
   end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -36,7 +36,16 @@ class List < ApplicationRecord
   def as_json(*)
     super({
       only: [:id, :name],
-      include: :items
+      include: {
+        items: {
+          only: [
+            :name,
+            :person,
+            :department,
+            :bought
+          ]
+        }
+      }
       }).merge({
         unbought_count: items.unbought.count,
         item_count: items.active.count

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -45,7 +45,7 @@ class ListTest < ActiveSupport::TestCase
     )
     assert_equal(
       {
-        "id"=>980190963,
+        "id"=>list.id,
         "name"=>"Shopping Place",
         "items"=>[
           {

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -15,4 +15,56 @@ class ListTest < ActiveSupport::TestCase
     list = List.create(name: "")
     refute list.valid?
   end
+
+  test "as_json call on list with no items returns expected output" do
+    list = List.create(name: "Shopping Place", id: 1)
+    assert_equal(
+      {
+        "id"=>1,
+        "name"=>"Shopping Place",
+        "items"=>[],
+        :unbought_count=>0,
+        :item_count=>0
+      },
+      list.as_json
+    )
+  end
+
+  test "as_json call on list with items returns expected output" do
+    user = User.create(username: "Person", uid: "31415", provider: "lols")
+    list = List.create(user: user, name: "Shopping Place")
+    list.items.create(
+      name: "Item 1",
+      person: "Person 1",
+      department: "Department 1"
+    )
+    list.items.create(
+      name: "Item 2",
+      person: "Person 2",
+      department: "Department 2"
+    )
+    assert_equal(
+      {
+        "id"=>980190963,
+        "name"=>"Shopping Place",
+        "items"=>[
+          {
+            "name"=>"Item 1",
+            "person"=>"Person 1",
+            "department"=>"Department 1",
+            "bought"=>false
+          },
+          {
+            "name"=>"Item 2",
+            "person"=>"Person 2",
+            "department"=>"Department 2",
+            "bought"=>false
+          }
+        ],
+        :unbought_count=>0,
+        :item_count=>0
+      },
+      list.as_json
+    )
+  end
 end


### PR DESCRIPTION
- Added "unbought" attribute to `List` model
- Added `as_json` method to `List` model to handle what gets sent to the front end so the display can show the item counts.
- Added a badge to the `ListEntry` component that displays the "not yet bought items" / "total active items in the list."

![Capture](https://user-images.githubusercontent.com/74803363/124976767-4c98dc80-dff5-11eb-9db4-7c9b453ebd3f.PNG)
