### PR TITLE
Convert how Item Table is displayed:

### DIFF
--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -10,11 +10,12 @@
 }
 
 .bought-col {
-    width: 90px;
+    @extend .col-2;
+    //width: 90px;
 }
 
 .text-col {
-    width: 175px;
+    //width: 175px;
 }
 
 .quantity-col {

--- a/app/javascript/components/items/Editable.js
+++ b/app/javascript/components/items/Editable.js
@@ -9,6 +9,7 @@ const Editable = ({
   ...props
 }) => {
   const [isEditing, setEditing] = useState(false);
+  const { handleFinishEditing, ...rest } = props;
 
   useEffect(() => {
     if (childRef && childRef.current && isEditing === true) {
@@ -18,11 +19,11 @@ const Editable = ({
 
   const onBlur = () => {
     setEditing(false);
-    props.onFinishEditing();
+    handleFinishEditing();
   }
 
   return (
-    <section {...props}>
+    <section {...rest}>
       {isEditing ? (
         <div onBlur={onBlur} >
           {children}

--- a/app/javascript/components/items/EditableField.js
+++ b/app/javascript/components/items/EditableField.js
@@ -21,7 +21,7 @@ function EditableField(props) {
 
   return (
     <React.Fragment>
-      <Editable text={fieldValue} childRef={inputRef} onFinishEditing={persistField}>
+      <Editable text={fieldValue} childRef={inputRef} handleFinishEditing={() => persistField()}>
         <input ref={inputRef} type="text" name={props.field} value={fieldValue} onChange={e => setFieldValue(e.target.value)} />
       </Editable>
     </React.Fragment>

--- a/app/javascript/components/items/PreviousDatalists.js
+++ b/app/javascript/components/items/PreviousDatalists.js
@@ -15,9 +15,9 @@ class PreviousDatalists extends React.Component {
   render () {
     return (
       <React.Fragment>
-        <Datalist key="name" data_key="name" data={this.props.previous_item_data.names} />
-        <Datalist key="person" data_key="person" data={this.props.previous_item_data.people} />
-        <Datalist key="department" data_key="department" data={this.props.previous_item_data.departments} />
+        <Datalist key="name" data_key="name" data={this.props.previousItemData.names} />
+        <Datalist key="person" data_key="person" data={this.props.previousItemData.people} />
+        <Datalist key="department" data_key="department" data={this.props.previousItemData.departments} />
       </React.Fragment>
     );
   }

--- a/app/javascript/components/lists/ListGroup.js
+++ b/app/javascript/components/lists/ListGroup.js
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from "react"
 import ListEntry from "./ListEntry"
+import PreviousDataLists from "../items/PreviousDatalists"
+import Table from "../items/Table"
 
 const ListGroup = (props) => {
   const [lists, setLists] = useState(props.lists);
 
   const csrf = props.csrf;
+  const previous_item_data = props.previous_item_data;
   const inputRef = React.useRef(null);
 
   const handleStateChange = ( listId ) => {
@@ -43,20 +46,20 @@ const ListGroup = (props) => {
     )
   }
 
-  var display;
+  var displayLists;
+  var displayItems;
 
-  const renderDisplay = () => {
+  const renderLists = () => {
     if( lists.length > 0 ){
-      display =
+      displayLists =
         <div>
           <h3 className="text-center">Lists</h3>
           <div className="list-group">
             {lists.map(displayList)}
           </div>
-          <h3 className="text-center">Items</h3>
         </div>
     } else {
-      display =
+      displayLists =
         <div className="text-center">
           <h3>
             Create a list to begin!
@@ -65,11 +68,54 @@ const ListGroup = (props) => {
     }
   }
 
+  const displayItem = (list, index) => {
+    let isActive = "";
+    if(index == 0){
+      isActive = "active";
+    }
+    let className = "shopping-list tab-pane fade show " + isActive;
+    let id = "list-" + list.id;
+    return(
+      <div key={list.id} className={className} id={id}>
+        <Table
+          key={list.id}
+          id={list.id}
+          previous_item_data={previous_item_data}
+          items={list.items}
+          csrf={csrf}
+        />
+      </div>
+    )
+  }
+
+  const renderItems = () => {
+    if( lists.length > 0 ){
+      displayItems =
+        <div>
+          <h3 className="text-center">Items</h3>
+          <div className="row mt-4 text-center">
+            <div className="tab-content" id="nav-tabContent">
+              {lists.map(displayItem)}
+            </div>
+          </div>
+        </div>
+    } else {
+      displayItems =
+        <div className="text-center">
+          <h3>
+            Create a list to begin!
+          </h3>
+        </div>
+    }
+  }
   
   return (
     <React.Fragment>
-      {renderDisplay()}
-      {display}
+      <PreviousDataLists key="previous_item_data" previous_item_data={props.previous_item_data} />
+      {renderLists()}
+      {displayLists}
+      {renderItems()}
+      {displayItems}
     </React.Fragment>
   );
 }

--- a/app/javascript/components/lists/ListGroup.js
+++ b/app/javascript/components/lists/ListGroup.js
@@ -7,7 +7,7 @@ const ListGroup = (props) => {
   const [lists, setLists] = useState(props.lists);
 
   const csrf = props.csrf;
-  const previous_item_data = props.previous_item_data;
+  const previousItemData = props.previousItemData;
   const inputRef = React.useRef(null);
 
   const handleStateChange = ( listId ) => {
@@ -80,7 +80,7 @@ const ListGroup = (props) => {
         <Table
           key={list.id}
           id={list.id}
-          previous_item_data={previous_item_data}
+          previousItemData={previousItemData}
           items={list.items}
           csrf={csrf}
         />
@@ -111,7 +111,7 @@ const ListGroup = (props) => {
   
   return (
     <React.Fragment>
-      <PreviousDataLists key="previous_item_data" previous_item_data={props.previous_item_data} />
+      <PreviousDataLists key="previousItemData" previousItemData={props.previousItemData} />
       {renderLists()}
       {displayLists}
       {renderItems()}

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -42,13 +42,16 @@ class List < ApplicationRecord
             :name,
             :person,
             :department,
-            :bought
+            :bought,
+            :id,
+            :quantity
           ]
         }
       }
       }).merge({
         unbought_count: items.unbought.count,
-        item_count: items.active.count
+        item_count: items.active.count,
+        active: items.active
       })
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,21 +11,11 @@
           <% end %>
         </div>
       </div>
-
       <div class="row pt-4">
         <div class="col-10 offset-1">
-          <%= react_component("lists/ListGroup", { lists: @all_lists, csrf: form_authenticity_token  })%>
+          <%= react_component("lists/ListGroup", { lists: @all_lists, previous_item_data: @previous_item_data, csrf: form_authenticity_token  })%>
         </div>
       </div>
-
-      <% if @all_lists.length > 0 %>
-        <div class="row pb-4 text-center">
-          <div class="col-5">
-            <%= render "items/items_table", collection: current_user %>
-          </div>
-        </div>
-      <% end %>
-      
   <% else %>
     <div class="call-to-action">
       <div class="row mt-3">

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -49,20 +49,25 @@ class ListTest < ActiveSupport::TestCase
         "name"=>"Shopping Place",
         "items"=>[
           {
+            "id"=>nil,
             "name"=>"Item 1",
             "person"=>"Person 1",
             "department"=>"Department 1",
-            "bought"=>false
+            "bought"=>false,
+            "quantity"=>nil
           },
           {
+            "id"=>nil,
             "name"=>"Item 2",
             "person"=>"Person 2",
             "department"=>"Department 2",
-            "bought"=>false
+            "bought"=>false,
+            "quantity"=>nil
           }
         ],
         :unbought_count=>0,
-        :item_count=>0
+        :item_count=>0,
+        :active=>list.items.active
       },
       list.as_json
     )

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -24,7 +24,8 @@ class ListTest < ActiveSupport::TestCase
         "name"=>"Shopping Place",
         "items"=>[],
         :unbought_count=>0,
-        :item_count=>0
+        :item_count=>0,
+        :active=>list.items.active
       },
       list.as_json
     )


### PR DESCRIPTION
- Moved the `Table` component to be a child of `ListGroup` (in a later PR this will be cleaned up and separated into different components)
- Fix persistent warning regarding `onFinishEditing`
- Add `:id`, `:quantity`, and `:active` as part of what is allowed to be passed `as_json` to the front-end

![Capture](https://user-images.githubusercontent.com/74803363/125125027-a5807780-e0be-11eb-9308-15965cf1ea88.PNG)

Co-authored-by: Andrew Nordman <cadwallion@github.com>