### PR TITLE
List sharing functionality

### DIFF
--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -5,26 +5,24 @@ class SharedListsController < ApplicationController
     list_id = shared_params[:list_id]
     email = shared_params[:email]
     user_list_shared_with = User.find_by(email: email)
-    if user_list_shared_with
-      @shared_list = SharedList.new(
-        list_id: list_id,
-        user_id: user_list_shared_with.id
-      )
-      if @shared_list.save
-        respond_to do |format|
-          format.html { redirect_to root_path,
-            notice: "#{List.find_by(id: list_id).name} shared with #{email}"
+    @shared_list = SharedList.new(
+      list_id: list_id,
+      user_id: user_list_shared_with&.id
+    )
+    if @shared_list.save
+      respond_to do |format|
+        format.html { redirect_to root_path,
+          notice: "#{List.find_by(id: list_id).name} shared with #{email}"
+        }
+        format.json { render json: {
+          message: "#{List.find_by(id: list_id).name} shared with #{email}"
           }
-          format.json { render json: {
-            message: "#{List.find_by(id: list_id).name} shared with #{email}"
-            }
-          }
-        end
+        }
       end
     else
       respond_to do |format|
-        format.html { redirect_to root_path, notice: "User with that email was not found" }
-        format.json { render json: { message: "User with that email was not found" } }
+        format.html { redirect_to root_path, notice: @shared_list.errors.full_messages }
+        format.json { render json: { message: @shared_list.errors.full_messages } }
       end
     end
   end

--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -1,0 +1,37 @@
+class SharedListsController < ApplicationController
+  before_action :require_user_logged_in!
+
+  def create
+    list_id = shared_params[:list_id]
+    email = shared_params[:email]
+    user_list_shared_with = User.find_by(email: email)
+    if user_list_shared_with
+      @shared_list = SharedList.new(
+        list_id: list_id,
+        user_id: user_list_shared_with.id
+      )
+      if @shared_list.save
+        respond_to do |format|
+          format.html { redirect_to root_path,
+            notice: "#{List.find_by(id: list_id).name} shared with #{email}"
+          }
+          format.json { render json: {
+            message: "#{List.find_by(id: list_id).name} shared with #{email}"
+            }
+          }
+        end
+      end
+    else
+      respond_to do |format|
+        format.html { redirect_to root_path, notice: "User with that email was not found" }
+        format.json { render json: { message: "User with that email was not found" } }
+      end
+    end
+  end
+
+  private
+
+  def shared_params
+    params.permit(:list_id, :email, :shared_list)
+  end
+end

--- a/app/javascript/components/lists/ListEntry.js
+++ b/app/javascript/components/lists/ListEntry.js
@@ -22,7 +22,7 @@ const ListEntry = (props) => {
         aria-controls={ariaControls}
         >
         <span className="p-0 m-0 flex-grow-1 me-auto list-name">{list.name}</span>
-        <ListGroupButtons key={list.id} list={list} csrf={csrf} setState={props.handleStateChange} />
+        <ListGroupButtons key={list.id} list={list} csrf={csrf} handleStateChange={props.handleStateChange} setState={props.setState} />
       </a>
     </React.Fragment>
   )

--- a/app/javascript/components/lists/ListGroup.js
+++ b/app/javascript/components/lists/ListGroup.js
@@ -27,6 +27,11 @@ const ListGroup = (props) => {
     })
   }
 
+  const setState = () => {
+    console.log("State Set");
+    // window.location.reload();
+  }
+
   const displayList = (list, index) => {
     let isActive = false;
     if(index == 0){
@@ -38,6 +43,7 @@ const ListGroup = (props) => {
         list={list}
         csrf={csrf}
         handleStateChange={handleStateChange}
+        setState={setState}
         isActive={isActive}
       />
     )

--- a/app/javascript/components/lists/ListGroup.js
+++ b/app/javascript/components/lists/ListGroup.js
@@ -28,7 +28,7 @@ const ListGroup = (props) => {
   }
 
   const setState = () => {
-    console.log("State Set");
+    // console.log("State Set");
     // window.location.reload();
   }
 

--- a/app/javascript/components/lists/ListGroupButtons.js
+++ b/app/javascript/components/lists/ListGroupButtons.js
@@ -48,7 +48,12 @@ const ListGroupButtons = (props) => {
         "Accept": "application/json",
         "X-CSRF-Token": csrf,
       }
-    }).then(response => props.setState());
+    })
+    .then(response => response.json)
+    .then(json_response => {
+      console.log("json_response: " + json_response.message);
+    })
+    .then(response => props.setState());
   }
 
   const confirmDelete = () => {

--- a/app/javascript/components/lists/ListGroupButtons.js
+++ b/app/javascript/components/lists/ListGroupButtons.js
@@ -49,7 +49,7 @@ const ListGroupButtons = (props) => {
         "X-CSRF-Token": csrf,
       }
     })
-    .then(response => response.json)
+    .then(response => response.json())
     .then(json_response => {
       console.log("json_response: " + json_response.message);
     })

--- a/app/javascript/components/lists/ListGroupButtons.js
+++ b/app/javascript/components/lists/ListGroupButtons.js
@@ -36,6 +36,19 @@ const ListGroupButtons = (props) => {
 
   const shareClicked = () => {
     console.log("List: " + list.name + " shared with " + document.getElementById("email").value);
+    const data = {
+      list_id: list.id,
+      email: document.getElementById("email").value
+    }
+    fetch("/shared_lists/", {
+      method: "POST",
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "X-CSRF-Token": csrf,
+      }
+    }).then(response => props.setState());
   }
 
   const confirmDelete = () => {
@@ -48,7 +61,7 @@ const ListGroupButtons = (props) => {
         "Accept": "application/json",
         "X-CSRF-Token": csrf,
       }
-    }).then(response => props.setState(list.id));
+    }).then(response => props.handleStateChange(list.id));
   }
 
   return (

--- a/app/models/shared_list.rb
+++ b/app/models/shared_list.rb
@@ -1,4 +1,10 @@
 class SharedList < ApplicationRecord
   belongs_to :user
   belongs_to :list
+
+  validates :user, 
+    exclusion: { 
+      in: -> (shared_list) { [shared_list.list.user] }, 
+      message: "cannot be yourself",
+   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   resources :items do
     post :remove, on: :member
   end
+  resources :shared_lists
 end


### PR DESCRIPTION
- Create `SharedListController` that is responsible defining the create method so a `SharedList` relation can be created to share lists.
- Add second `setState` to send to `ListEntry` to pass off to `listGroupButtons` that handles the state change for the `shareClicked` method.
- Implement fetch call to API so a POST call creates the `SharedList` model.

![Capture](https://user-images.githubusercontent.com/74803363/125133363-64db2b00-e0cb-11eb-827f-e2884312d331.PNG)

Co-authored-by: Andrew Nordman cadwallion@github.com