### PR TITLE
Fix remove bought functionality

### DIFF
--- a/app/javascript/components/lists/ListGroup.js
+++ b/app/javascript/components/lists/ListGroup.js
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from "react"
-import ListEntry from "./ListEntry"
-import PreviousDataLists from "../items/PreviousDatalists"
-import Table from "../items/Table"
+import React, { useState, useEffect } from "react";
+import ListEntry from "./ListEntry";
+import PreviousDataLists from "../items/PreviousDatalists";
+import Table from "../items/Table";
 
 const ListGroup = (props) => {
   const [lists, setLists] = useState(props.lists);
@@ -10,87 +10,84 @@ const ListGroup = (props) => {
   const previousItemData = props.previousItemData;
   const inputRef = React.useRef(null);
 
-  const handleStateChange = ( listId ) => {
-
+  const handleStateChange = (listId) => {
     var newLists = [...lists];
 
-    newLists.map((list, index) =>{
+    newLists.map((list, index) => {
       let id = list.id;
-      if( id === listId ){
+      if (id === listId) {
         newLists.splice(index, 1);
         setLists(newLists);
       }
 
-      if( newLists.length > 0 ){
-        let id = ("list-" + newLists[0].id + "-list");
+      if (newLists.length > 0) {
+        let id = "list-" + newLists[0].id + "-list";
         document.getElementById(id).click();
       } else {
         window.location.reload();
       }
-    })
-  }
+    });
+  };
 
   const displayList = (list, index) => {
     let isActive = false;
-    if(index == 0){
+    if (index == 0) {
       isActive = true;
     }
-    return(
-      <ListEntry 
+    return (
+      <ListEntry
         key={list.id}
         list={list}
         csrf={csrf}
         handleStateChange={handleStateChange}
         isActive={isActive}
       />
-    )
-  }
+    );
+  };
 
   var displayLists;
   var displayItems;
 
   const renderLists = () => {
-    if( lists.length > 0 ){
-      displayLists =
+    if (lists.length > 0) {
+      displayLists = (
         <div>
           <h3 className="text-center">Lists</h3>
-          <div className="list-group">
-            {lists.map(displayList)}
-          </div>
+          <div className="list-group">{lists.map(displayList)}</div>
         </div>
+      );
     } else {
-      displayLists =
+      displayLists = (
         <div className="text-center">
-          <h3>
-            Create a list to begin!
-          </h3>
+          <h3>Create a list to begin!</h3>
         </div>
+      );
     }
-  }
+  };
 
   const displayItem = (list, index) => {
     let isActive = "";
-    if(index == 0){
+    if (index == 0) {
       isActive = "active";
     }
     let className = "shopping-list tab-pane fade show " + isActive;
     let id = "list-" + list.id;
-    return(
+    return (
       <div key={list.id} className={className} id={id}>
         <Table
           key={list.id}
           id={list.id}
           previousItemData={previousItemData}
-          items={list.items}
+          items={list.items.filter((item) => item.active)}
           csrf={csrf}
         />
       </div>
-    )
-  }
+    );
+  };
 
   const renderItems = () => {
-    if( lists.length > 0 ){
-      displayItems =
+    if (lists.length > 0) {
+      displayItems = (
         <div>
           <h3 className="text-center">Items</h3>
           <div className="row mt-4 text-center">
@@ -99,25 +96,28 @@ const ListGroup = (props) => {
             </div>
           </div>
         </div>
+      );
     } else {
-      displayItems =
+      displayItems = (
         <div className="text-center">
-          <h3>
-            Create a list to begin!
-          </h3>
+          <h3>Create a list to begin!</h3>
         </div>
+      );
     }
-  }
-  
+  };
+
   return (
     <React.Fragment>
-      <PreviousDataLists key="previousItemData" previousItemData={props.previousItemData} />
+      <PreviousDataLists
+        key="previousItemData"
+        previousItemData={props.previousItemData}
+      />
       {renderLists()}
       {displayLists}
       {renderItems()}
       {displayItems}
     </React.Fragment>
   );
-}
+};
 
-export default ListGroup
+export default ListGroup;

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,4 +25,23 @@ class Item < ApplicationRecord
   def add_back_to_list
     update(quantity: 1, deleted_at: nil, bought: false)
   end
+
+  def active
+    deleted_at.nil?
+  end
+
+  def serializable_hash(*)
+    super({
+      only: [
+        :name,
+        :person,
+        :department,
+        :bought,
+        :id,
+        :quantity,
+      ],
+    }).merge(
+      active: active
+    )
+  end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -36,18 +36,7 @@ class List < ApplicationRecord
   def as_json(*)
     super({
       only: [:id, :name],
-      include: {
-        items: {
-          only: [
-            :name,
-            :person,
-            :department,
-            :bought,
-            :id,
-            :quantity
-          ]
-        }
-      }
+      include: [:items]
       }).merge({
         unbought_count: items.unbought.count,
         item_count: items.active.count,

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,7 @@
       </div>
       <div class="row pt-4">
         <div class="col-10 offset-1">
-          <%= react_component("lists/ListGroup", { lists: @all_lists, previous_item_data: @previous_item_data, csrf: form_authenticity_token  })%>
+          <%= react_component("lists/ListGroup", { lists: @all_lists, previousItemData: @previous_item_data, csrf: form_authenticity_token  })%>
         </div>
       </div>
   <% else %>

--- a/app/views/items/_items_table.html.erb
+++ b/app/views/items/_items_table.html.erb
@@ -1,9 +1,9 @@
 <div class="row mt-4 text-center">
   <div class="tab-content" id="nav-tabContent">
-    <%= react_component("items/PreviousDatalists", { previous_item_data: @previous_item_data })%>
+    <%= react_component("items/PreviousDatalists", { previousItemData: @previous_item_data })%>
     <% current_user.lists.each_with_index do |list, index| %>
       <%= tag.div class: "shopping-list tab-pane fade show #{index == 0 ? 'active' : ''}", id: "list-#{list.id}" do %>
-        <%= react_component("items/Table", { id: list.id, previous_item_data: @previous_item_data, items: list.items.active, csrf: form_authenticity_token }) %>
+        <%= react_component("items/Table", { id: list.id, previousItemData: @previous_item_data, items: list.items.active, csrf: form_authenticity_token }) %>
       <% end %>
     <% end %>
   </div>

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -46,30 +46,32 @@ class ListTest < ActiveSupport::TestCase
     )
     assert_equal(
       {
-        "id"=>list.id,
+        "id"=>980190963,
         "name"=>"Shopping Place",
-        "items"=>[
+        "items"=>
+        [
           {
             "id"=>nil,
             "name"=>"Item 1",
             "person"=>"Person 1",
             "department"=>"Department 1",
             "bought"=>false,
-            "quantity"=>nil
-          },
-          {
-            "id"=>nil,
-            "name"=>"Item 2",
-            "person"=>"Person 2",
-            "department"=>"Department 2",
-            "bought"=>false,
-            "quantity"=>nil
-          }
-        ],
-        :unbought_count=>0,
-        :item_count=>0,
-        :active=>list.items.active
-      },
+            "quantity"=>nil,
+            "active"=>true},
+            {
+              "id"=>nil,
+              "name"=>"Item 2",
+              "person"=>"Person 2",
+              "department"=>"Department 2",
+              "bought"=>false,
+              "quantity"=>nil,
+              "active"=>true
+            }
+          ],
+            :unbought_count=>0,
+            :item_count=>0,
+            :active=>list.items.active
+        },
       list.as_json
     )
   end


### PR DESCRIPTION
### Fix Remove Bought Functionality
*This PR resolves Issue: #64 

- Fix inconsistent camel case conventions from "PreviousItemData" to "previousItemData"
- Fix minor syntactical nits
- add `active` method to `item.rb` model
- add `serializable_hash` method to `item.rb` model that handles what data get's sent to the front end
- change `as_json` method in `list.rb` since the `include:` section no longer needs to be explicit with the changes made to `item.rb`

Co-authored-by: Andrew Nordman cadwallion@github.com