### PR TITLE
fix items unbought and active being displayed

### DIFF
--- a/app/javascript/components/lists/ListEntry.js
+++ b/app/javascript/components/lists/ListEntry.js
@@ -9,7 +9,7 @@ const ListEntry = (props) => {
   const ariaControls = "list-" + list.id;
   const id = ariaControls + "-list";
   const href = "#list-" + list.id;
-  const badgeItemCount = (list.unbought_count) + "/" + (list.item_count);
+  const badgeItemCount = (list.unbought_and_active) + "/" + (list.item_count);
 
   return (
     <React.Fragment>

--- a/app/javascript/components/lists/ListEntry.js
+++ b/app/javascript/components/lists/ListEntry.js
@@ -9,7 +9,7 @@ const ListEntry = (props) => {
   const ariaControls = "list-" + list.id;
   const id = ariaControls + "-list";
   const href = "#list-" + list.id;
-  const badgeItemCount = (list.unbought_and_active) + "/" + (list.item_count);
+  const badgeItemCount = (list.unbought) + "/" + (list.item_count);
 
   return (
     <React.Fragment>

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -41,7 +41,7 @@ class List < ApplicationRecord
       only: [:id, :name],
       include: [:items]
       }).merge({
-        unbought_and_active: items.unbought_and_active.count,
+        unbought: items.unbought_and_active.count,
         item_count: items.active.count,
         active: items.active
       })

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -11,6 +11,9 @@ class List < ApplicationRecord
     def unbought
       where(bought: false)
     end
+    def unbought_and_active
+      where(bought: false).where(deleted_at: nil)
+    end
   end
   validates :name, length: { minimum: 1 }
   validates :name, uniqueness: true;
@@ -38,7 +41,7 @@ class List < ApplicationRecord
       only: [:id, :name],
       include: [:items]
       }).merge({
-        unbought_count: items.unbought.count,
+        unbought_and_active: items.unbought_and_active.count,
         item_count: items.active.count,
         active: items.active
       })

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -23,7 +23,7 @@ class ListTest < ActiveSupport::TestCase
         "id"=>1,
         "name"=>"Shopping Place",
         "items"=>[],
-        :unbought_and_active=>0,
+        :unbought=>0,
         :item_count=>0,
         :active=>list.items.active
       },
@@ -68,7 +68,7 @@ class ListTest < ActiveSupport::TestCase
               "active"=>true
             }
           ],
-            :unbought_and_active=>0,
+            :unbought=>0,
             :item_count=>0,
             :active=>list.items.active
         },

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -23,7 +23,7 @@ class ListTest < ActiveSupport::TestCase
         "id"=>1,
         "name"=>"Shopping Place",
         "items"=>[],
-        :unbought_count=>0,
+        :unbought_and_active=>0,
         :item_count=>0,
         :active=>list.items.active
       },
@@ -68,7 +68,7 @@ class ListTest < ActiveSupport::TestCase
               "active"=>true
             }
           ],
-            :unbought_count=>0,
+            :unbought_and_active=>0,
             :item_count=>0,
             :active=>list.items.active
         },


### PR DESCRIPTION
### Fix Items that are unbought and active being counted correctly in the `ListEntry` badge (##)
Resolves Issue: #67 

- Create new item association method to define when an item is both unbought and active.
- Change all variable names associated with the new method reference for clarity.

This makes it so items that are unbought and inactive will not be included in the badge count resulting in cases like (5/4). 