### PR TITLE
Enable shared list name says shared

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@ class HomeController < ApplicationController
   def index
     @previous_item_data = Item.previous_item_data current_user
     if current_user
-      @all_lists = current_user.lists + current_user.user_shared_lists
+      @all_lists = ListsSerializer.new((current_user.lists + current_user.user_shared_lists), current_user)
     else
       @all_lists = []
     end

--- a/app/javascript/components/lists/ListEntry.js
+++ b/app/javascript/components/lists/ListEntry.js
@@ -1,15 +1,18 @@
-import React from "react"
-import ListGroupButtons from "./ListGroupButtons"
+import React from "react";
+import ListGroupButtons from "./ListGroupButtons";
 
 const ListEntry = (props) => {
   const list = props.list;
   const csrf = props.csrf;
-  let activeClass = (props.isActive) ? " active" : "";
-  const className = "list-group-item list-group-item-action d-flex" + activeClass;
+  let activeClass = props.isActive ? " active" : "";
+  const className =
+    "list-group-item list-group-item-action d-flex" + activeClass;
   const ariaControls = "list-" + list.id;
   const id = ariaControls + "-list";
   const href = "#list-" + list.id;
-  const badgeItemCount = (list.unbought) + "/" + (list.item_count);
+  const badgeItemCount = list.unbought + "/" + list.item_count;
+
+  const listName = list.name;
 
   return (
     <React.Fragment>
@@ -21,15 +24,22 @@ const ListEntry = (props) => {
         href={href}
         role="tab"
         aria-controls={ariaControls}
-        >
-        <span className="p-0 m-0 flex-grow-1 me-auto list-name">{list.name}</span>
+      >
+        <span className="p-0 m-0 flex-grow-1 me-auto list-name">
+          {list.name}
+        </span>
         <span className="badge bg-primary rounded-pill item-count">
           <span className="align-middle">{badgeItemCount}</span>
         </span>
-        <ListGroupButtons key={list.id} list={list} csrf={csrf} setState={props.handleStateChange} />
+        <ListGroupButtons
+          key={list.id}
+          list={list}
+          csrf={csrf}
+          setState={props.handleStateChange}
+        />
       </a>
     </React.Fragment>
-  )
-}
+  );
+};
 
-export default ListEntry
+export default ListEntry;

--- a/app/javascript/components/lists/ListEntry.js
+++ b/app/javascript/components/lists/ListEntry.js
@@ -11,8 +11,8 @@ const ListEntry = (props) => {
   const id = ariaControls + "-list";
   const href = "#list-" + list.id;
   const badgeItemCount = list.unbought + "/" + list.item_count;
-
-  const listName = list.name;
+  const sharedName = list.shared ? " (shared)" : "";
+  const listName = list.name + sharedName;
 
   return (
     <React.Fragment>
@@ -26,7 +26,7 @@ const ListEntry = (props) => {
         aria-controls={ariaControls}
       >
         <span className="p-0 m-0 flex-grow-1 me-auto list-name">
-          {list.name}
+          {listName}
         </span>
         <span className="badge bg-primary rounded-pill item-count">
           <span className="align-middle">{badgeItemCount}</span>

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -39,15 +39,4 @@ class List < ApplicationRecord
   def is_shared_with?(u)
     user != u
   end
-
-  def as_json(*)
-    super({
-      only: [:id, :name],
-      include: [:items]
-      }).merge({
-        unbought: items.unbought_and_active.count,
-        item_count: items.active.count,
-        active: items.active,
-      })
-  end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -36,6 +36,10 @@ class List < ApplicationRecord
     item
   end
 
+  def is_shared_with?(u)
+    user != u
+  end
+
   def as_json(*)
     super({
       only: [:id, :name],
@@ -43,7 +47,7 @@ class List < ApplicationRecord
       }).merge({
         unbought: items.unbought_and_active.count,
         item_count: items.active.count,
-        active: items.active
+        active: items.active,
       })
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :shared_lists
   has_many :lists, dependent: :destroy
-  has_many :user_shared_lists, :through => :shared_lists, class_name: "List", :source => :user
+  has_many :user_shared_lists, :through => :shared_lists, class_name: "List", :source => :list
   validates :provider, presence: true
   validates :uid, presence: true
   validates :username, presence: true

--- a/app/seralizers/lists_serializer.rb
+++ b/app/seralizers/lists_serializer.rb
@@ -1,0 +1,20 @@
+class ListsSerializer
+  def initialize(lists, user)
+    @lists = lists
+    @user = user
+  end
+
+  def as_json(*)
+    @lists.map do |list|
+      list.as_json({
+        only: [:id, :name],
+        include: [:items]
+      }).merge({
+        unbought: list.items.unbought_and_active.count,
+        item_count: list.items.active.count,
+        active: list.items.active,
+        shared: list.is_shared_with?(@user)
+      })
+    end
+  end
+end

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -21,11 +21,10 @@ class ListTest < ActiveSupport::TestCase
     assert_equal(
       {
         "id"=>1,
+        "user_id"=>list.user_id,
         "name"=>"Shopping Place",
-        "items"=>[],
-        :unbought=>0,
-        :item_count=>0,
-        :active=>list.items.active
+        "created_at"=>list.created_at,
+        "updated_at"=>list.updated_at,
       },
       list.as_json
     )
@@ -47,31 +46,11 @@ class ListTest < ActiveSupport::TestCase
     assert_equal(
       {
         "id"=>980190963,
+        "user_id"=>list.user_id,
         "name"=>"Shopping Place",
-        "items"=>
-        [
-          {
-            "id"=>nil,
-            "name"=>"Item 1",
-            "person"=>"Person 1",
-            "department"=>"Department 1",
-            "bought"=>false,
-            "quantity"=>nil,
-            "active"=>true},
-            {
-              "id"=>nil,
-              "name"=>"Item 2",
-              "person"=>"Person 2",
-              "department"=>"Department 2",
-              "bought"=>false,
-              "quantity"=>nil,
-              "active"=>true
-            }
-          ],
-            :unbought=>0,
-            :item_count=>0,
-            :active=>list.items.active
-        },
+        "created_at"=>list.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
+        "updated_at"=>list.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
+      },
       list.as_json
     )
   end


### PR DESCRIPTION
### Change how data is sent from the backend to front end & show shared list on UI
- Make minor syntactical fixes
- Create `ListsSerializer` class that is responsible deciding what data is sent to the front end and serializing it
- Update `ListEntry` so if a list is a shared list (not owned/created) the name is appended with " (Shared)."
- Add method to `List.rb` called `is_shared_with` that determines if a list is shared with a user or not
- Fix association `has_many :user_shared_lists` in `user.rb` so the source value is `:list` not `:user`
- Fix two tests that needed new formatting do to the serialization changes