### PR TITLE
when creating user email column is now populated

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
 
   def self.create_with_omniauth(auth)
     create! do |user|
+      user.email = auth["info"]["email"]
       user.provider = auth["provider"]
       user.uid = auth["uid"]
       user.username = auth["info"]["name"]


### PR DESCRIPTION
Previous to this PR, when a user logged in for the first time (new user model created) the `email` column was nil. This PR fixes that and populates `email` correctly.