### PR TITLE
Add additional info to `list entry`

### DIFF
--- a/app/javascript/components/lists/ListEntry.js
+++ b/app/javascript/components/lists/ListEntry.js
@@ -12,8 +12,8 @@ const ListEntry = (props) => {
   const href = "#list-" + list.id;
   const badgeItemCount = list.unbought + "/" + list.item_count;
   const sharedName = list.is_shared_with_user ? ` (Owner: ${list.shared_list_owner})` : "";
-  const numberSharedWith = list.number_shared_with;
-  const sharingText = (numberSharedWith > 0 && list.shared_list_owner == (props.user.first_name + " " + props.user.last_name)) ? ` (Shares: ${numberSharedWith})` : "";
+  const numberSharedWith = list.share_count;
+  const sharingText = (numberSharedWith > 0 && !list.is_shared_with_user) ? ` (Shares: ${numberSharedWith})` : "";
   const listName = list.name + sharedName + sharingText;
 
   return (

--- a/app/javascript/components/lists/ListEntry.js
+++ b/app/javascript/components/lists/ListEntry.js
@@ -11,8 +11,10 @@ const ListEntry = (props) => {
   const id = ariaControls + "-list";
   const href = "#list-" + list.id;
   const badgeItemCount = list.unbought + "/" + list.item_count;
-  const sharedName = list.shared ? " (shared)" : "";
-  const listName = list.name + sharedName;
+  const sharedName = list.is_shared_with_user ? ` (Owner: ${list.shared_list_owner})` : "";
+  const numberSharedWith = list.number_shared_with;
+  const sharingText = (numberSharedWith > 0 && list.shared_list_owner == (props.user.first_name + " " + props.user.last_name)) ? ` (Shares: ${numberSharedWith})` : "";
+  const listName = list.name + sharedName + sharingText;
 
   return (
     <React.Fragment>

--- a/app/javascript/components/lists/ListGroup.js
+++ b/app/javascript/components/lists/ListGroup.js
@@ -37,6 +37,7 @@ const ListGroup = (props) => {
     return (
       <ListEntry
         key={list.id}
+        user={props.user}
         list={list}
         csrf={csrf}
         handleStateChange={handleStateChange}
@@ -79,6 +80,8 @@ const ListGroup = (props) => {
           id={list.id}
           previousItemData={previousItemData}
           items={list.items.filter((item) => item.active)}
+          shared={list.is_shared_with_user}
+          sharedOwner={list.shared_list_owner}
           csrf={csrf}
         />
       </div>

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -39,4 +39,12 @@ class List < ApplicationRecord
   def is_shared_with?(u)
     user != u
   end
+
+  def shared_list_owner
+    user.first_name + " " + user.last_name
+  end
+
+  def number_shared_with
+    SharedList.where(list_id: self.id).length
+  end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -44,7 +44,7 @@ class List < ApplicationRecord
     user.first_name + " " + user.last_name
   end
 
-  def number_shared_with
+  def share_count
     SharedList.where(list_id: self.id).length
   end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -44,7 +44,7 @@ class List < ApplicationRecord
     user.first_name + " " + user.last_name
   end
 
-  def number_shared_with
+  def share_count
     SharedList.where(list_id: self.id).count
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
       user.uid = auth["uid"]
       user.username = auth["info"]["name"]
       user.image = auth["info"]["image"]
+      user.first_name = auth["info"]["first_name"]
+      user.last_name = auth["info"]["last_name"]
     end
   end
 end

--- a/app/seralizers/lists_serializer.rb
+++ b/app/seralizers/lists_serializer.rb
@@ -13,7 +13,9 @@ class ListsSerializer
         unbought: list.items.unbought_and_active.count,
         item_count: list.items.active.count,
         active: list.items.active,
-        shared: list.is_shared_with?(@user)
+        is_shared_with_user: list.is_shared_with?(@user),
+        shared_list_owner: list.shared_list_owner,
+        number_shared_with: list.number_shared_with
       })
     end
   end

--- a/app/seralizers/lists_serializer.rb
+++ b/app/seralizers/lists_serializer.rb
@@ -15,7 +15,7 @@ class ListsSerializer
         active: list.items.active,
         is_shared_with_user: list.is_shared_with?(@user),
         shared_list_owner: list.shared_list_owner,
-        number_shared_with: list.number_shared_with
+        share_count: list.share_count
       })
     end
   end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,7 @@
       </div>
       <div class="row pt-4">
         <div class="col-10 offset-1">
-          <%= react_component("lists/ListGroup", { lists: @all_lists, previousItemData: @previous_item_data, csrf: form_authenticity_token  })%>
+          <%= react_component("lists/ListGroup", { user: current_user, lists: @all_lists, previousItemData: @previous_item_data, csrf: form_authenticity_token  })%>
         </div>
       </div>
   <% else %>

--- a/db/migrate/20210824004150_add_first_and_last_names_to_user.rb
+++ b/db/migrate/20210824004150_add_first_and_last_names_to_user.rb
@@ -1,0 +1,6 @@
+class AddFirstAndLastNamesToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_21_173151) do
+ActiveRecord::Schema.define(version: 2021_08_24_004150) do
 
   create_table "items", force: :cascade do |t|
     t.integer "list_id", null: false
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2021_06_21_173151) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "image"
+    t.string "first_name"
+    t.string "last_name"
   end
 
   add_foreign_key "items", "lists"

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -5,6 +5,43 @@ class ListTest < ActiveSupport::TestCase
   #   assert true
   # end
 
+  setup do
+    List.destroy_all
+    SharedList.destroy_all
+    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
+  end
+
+  def setup_shared_lists!
+    @owner = User.create!(
+      email: "owner@test.com",
+      provider: "google_oauth2",
+      username: "Owner",
+      uid: 1,
+      first_name: "Owner",
+      last_name: "Test"
+    )
+    @shared_1 = User.create!(
+      email: "shared_1@test.com",
+      provider: "google_oauth2",
+      username: "shared_1",
+      uid: 2,
+      first_name: "shared_1",
+      last_name: "Test"
+    )
+    @shared_2 = User.create!(
+      email: "shared_2@test.com",
+      provider: "google_oauth2",
+      username: "shared_2",
+      uid: 3,
+      first_name: "shared_2",
+      last_name: "Test"
+    )
+    @owner.lists.create(name: "ShoppingPlace")
+    list = List.last
+    SharedList.create!(user_id: @shared_1.id, list_id: list.id)
+    SharedList.create!(user_id: @shared_2.id, list_id: list.id)
+  end
+
   test "only a list with a name is valid" do
     user = User.create(username: "Person", uid: "31415", provider: "lols")
     list = List.create(user: user, name: "Beer Run List")
@@ -31,21 +68,22 @@ class ListTest < ActiveSupport::TestCase
   end
 
   test "as_json call on list with items returns expected output" do
-    user = User.create(username: "Person", uid: "31415", provider: "lols")
-    list = List.create(user: user, name: "Shopping Place")
+    user = User.create!(username: "Person", uid: "31415", provider: "lols")
+    List.create(user_id: user.id, name: "Shopping Place")
+    list = List.last
     list.items.create(
       name: "Item 1",
       person: "Person 1",
       department: "Department 1"
-    )
+    ).save
     list.items.create(
       name: "Item 2",
       person: "Person 2",
       department: "Department 2"
-    )
+    ).save
     assert_equal(
       {
-        "id"=>980190963,
+        "id"=>list.id,
         "user_id"=>list.user_id,
         "name"=>"Shopping Place",
         "created_at"=>list.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
@@ -53,5 +91,34 @@ class ListTest < ActiveSupport::TestCase
       },
       list.as_json
     )
+  end
+
+  test "is_shared_with? returns correct outcome" do
+    setup_shared_lists!
+
+    assert_equal 2, SharedList.count
+
+    list = List.last
+    assert_equal true, list.is_shared_with?(@shared_1)
+    assert_equal true, list.is_shared_with?(@shared_2)
+  end
+
+  test "shared_list_owner returns correct list owner" do
+    setup_shared_lists!
+
+    assert_equal 2, SharedList.count
+
+    list = List.last
+    results = @owner.first_name + " " + @owner.last_name
+    assert_equal results, list.shared_list_owner
+  end
+
+  test "number_shared_with returns correct number of users list is shared with" do
+    setup_shared_lists!
+
+    assert_equal 2, SharedList.count
+
+    list = List.last
+    assert_equal 2, list.number_shared_with
   end
 end

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -113,12 +113,12 @@ class ListTest < ActiveSupport::TestCase
     assert_equal results, list.shared_list_owner
   end
 
-  test "number_shared_with returns correct number of users list is shared with" do
+  test "share_count returns correct number of users list is shared with" do
     setup_shared_lists!
 
     assert_equal 2, SharedList.count
 
     list = List.last
-    assert_equal 2, list.number_shared_with
+    assert_equal 2, list.share_count
   end
 end


### PR DESCRIPTION
### Add additional info to a list that is shared
The purpose of this PR is to add additional info to a list that is shared:
- If a shared list is owned by the `current_user`, they will see how many shares have been made.
- If a shared list is not owned by the `current_user`, they will see the owner of the list.

Changes:
- add two new columns to the user model: `first_name` & `last_name`. This will be used this PR and future ones when the `person` column in the items table can be auto-generated when a list is shared.
- Assign `first_name` & `last_name` to a new user when created.
- Added two new methods to `user.rb` so that pertinent data can be sent to the front end for display.
- Alter the serializer for a list so that the new data can be passed on to the front end.
- Alter the components that either receive or pass on the new data from the back end.

![Capture](https://user-images.githubusercontent.com/74803363/130699060-fed07d28-a21b-4cfc-8aff-44031a42f050.PNG)
![Capture2](https://user-images.githubusercontent.com/74803363/130699066-f44b8d16-4a8d-496b-bb2f-218eb9090d21.PNG)
![Capture3](https://user-images.githubusercontent.com/74803363/130699069-78e8bdfc-7072-4d85-98e3-f36d43eb349c.PNG)

