### PR TITLE
Add `display_location` boolean to `List` model

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,7 +53,7 @@ class ItemsController < ApplicationController
   end
 
   def item_params
-    params.permit(:bought, :name, :person, :department, :quantity)
+    params.permit(:bought, :name, :person, :location, :quantity)
   end
 
   def remove

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -19,14 +19,14 @@ class ListsController < ApplicationController
   def edit
     @previous_item_names = Item.joins(:list).where(list: { user: current_user}).pluck(:name).uniq
     @previous_item_people = Item.joins(:list).where(list: { user: current_user}).pluck(:person).uniq
-    @previous_item_departments = Item.joins(:list).where(list: { user: current_user}).pluck(:department).uniq
+    @previous_item_locations = Item.joins(:list).where(list: { user: current_user}).pluck(:location).uniq
     @list = List.find_by(id: params[:id])
   end
 
   def show
     @previous_item_names = Item.joins(:list).where(list: { user: current_user}).pluck(:name).uniq
     @previous_item_people = Item.joins(:list).where(list: { user: current_user}).pluck(:person).uniq
-    @previous_item_departments = Item.joins(:list).where(list: { user: current_user}).pluck(:department).uniq
+    @previous_item_locations = Item.joins(:list).where(list: { user: current_user}).pluck(:location).uniq
     @list = List.find_by(id: params[:id])
   end
 

--- a/app/javascript/components/items/PreviousDatalists.js
+++ b/app/javascript/components/items/PreviousDatalists.js
@@ -17,7 +17,7 @@ class PreviousDatalists extends React.Component {
       <React.Fragment>
         <Datalist key="name" data_key="name" data={this.props.previousItemData.names} />
         <Datalist key="person" data_key="person" data={this.props.previousItemData.people} />
-        <Datalist key="department" data_key="department" data={this.props.previousItemData.departments} />
+        <Datalist key="location" data_key="location" data={this.props.previousItemData.locations} />
       </React.Fragment>
     );
   }

--- a/app/javascript/components/items/Table.js
+++ b/app/javascript/components/items/Table.js
@@ -58,7 +58,7 @@ const ItemRow = (props) => {
       ) : (
         <td></td>
       )}
-      <td><EditableField id={item.id} field="department" text={item.department} csrf={props.csrf} /></td>
+      <td><EditableField id={item.id} field="location" text={item.location} csrf={props.csrf} /></td>
       <th scope="row"><QuantityController item={item} quantity={item.quantity} csrf={props.csrf} removeItem={props.removeItem}/></th>
     </tr>
   );
@@ -76,12 +76,12 @@ const Table = (props) => {
   const handleSubmit = (e) => {
     const nameField = e.target.closest("tr").querySelector("input[name=itemNameField]");
     const personField = e.target.closest("tr").querySelector("input[name=itemPersonField]");
-    const departmentField = e.target.closest("tr").querySelector("input[name=itemDepartmentField]");
+    const locationField = e.target.closest("tr").querySelector("input[name=itemLocationField]");
     const data = {
       list_id: props.id,
       name: nameField.value,
       person: e.target.closest("tr").querySelector("input[name=itemPersonField").value,
-      department: e.target.closest("tr").querySelector("input[name=itemDepartmentField").value,
+      location: e.target.closest("tr").querySelector("input[name=itemLocationField").value,
       quantity: 1
     };
     fetch("/items/", {
@@ -100,7 +100,7 @@ const Table = (props) => {
       requestSort(sortConfig.key, sortConfig.direction);
       nameField.value = "";
       personField.value = "";
-      departmentField.value = "";
+      locationField.value = "";
     });
   }
 
@@ -202,10 +202,10 @@ const Table = (props) => {
             <th className="text-col">
               <button
                 type="button"
-                onClick={() => requestSort("department")}
-                className={"btn btn-primary btn-sm " + getClassNamesFor("department")}
+                onClick={() => requestSort("location")}
+                className={"btn btn-primary btn-sm " + getClassNamesFor("location")}
               >
-                Department
+                Location
               </button>
             </th>
             <th className="quantity-col">
@@ -238,7 +238,7 @@ const Table = (props) => {
             </td>
             { personFooter }
             <td>
-              <input name="itemDepartmentField" placeholder="Department Name" list="item_department_datalist_options"/>
+              <input name="itemLocationField" placeholder="Location Name" list="item_location_datalist_options"/>
             </td>
             <td>
               <button className="btn btn-success btn-sm" onClick={handleSubmit}>Add Item</button>

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,17 +2,17 @@ class Item < ApplicationRecord
   belongs_to :list
   validates :name, presence: true, uniqueness: { scope: [:list_id, :person], message: "is already on the list for this person." }
   validates :person, presence: true
-  validates :department, presence: true
+  validates :location, presence: true
   validates :quantity, numericality: { greater_than_or_equal_to: 0 }
 
   def self.previous_item_data user
-    previous_items = Item.joins(:list).where(list: { user: user}).pluck(:name, :person, :department)
-    previous_data = { names: [], people: [], departments: [] }
+    previous_items = Item.joins(:list).where(list: { user: user}).pluck(:name, :person, :location)
+    previous_data = { names: [], people: [], locations: [] }
     
     previous_items.each do |item|
       previous_data[:names].push(item[0]) unless previous_data[:names].include? item[0]
       previous_data[:people].push(item[1]) unless previous_data[:people].include? item[1]
-      previous_data[:departments].push(item[2]) unless previous_data[:departments].include? item[2]
+      previous_data[:locations].push(item[2]) unless previous_data[:locations].include? item[2]
     end
 
     previous_data
@@ -35,7 +35,7 @@ class Item < ApplicationRecord
       only: [
         :name,
         :person,
-        :department,
+        :location,
         :bought,
         :id,
         :quantity,

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -22,14 +22,14 @@ class List < ApplicationRecord
     item = items.new(
       name: params[:name].downcase.camelize, 
       person: params[:person].downcase.camelize, 
-      department: params[:department].downcase.camelize, 
+      location: params[:location].downcase.camelize, 
       quantity: 1
     )
 
     if item.valid?
       item.name = params[:name]
       item.person = params[:person]
-      item.department = params[:department]
+      item.location = params[:location]
       item.save
     end
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <th scope="col">Name</th>
       <th scope="col">Person</th>
-      <th scope="col">Department</th>
+      <th scope="col">Location</th>
       <th scope="col">DELETE FOREVER
       </th>
     </tr>
@@ -33,8 +33,8 @@
            <%= react_component(
              "items/EditableField",
              { id: item.id,
-              field: "department",
-              text: item.department,
+              field: "location",
+              text: item.location,
               csrf: form_authenticity_token 
             }) %>
         </td>

--- a/app/views/lists/_form.html.erb
+++ b/app/views/lists/_form.html.erb
@@ -32,11 +32,11 @@
         </div>
 
         <div class="col-md-4">
-          <%= form.label :department, "Department:", class: "form-label" %>
-          <%= form.text_field :department, class: "form-control", list: "item_department_datalist_options" %>
-          <datalist id="item_department_datalist_options">
-            <% @previous_item_departments.each do |department| %>
-              <option><%= department %></option>
+          <%= form.label :location, "Location:", class: "form-label" %>
+          <%= form.text_field :location, class: "form-control", list: "item_location_datalist_options" %>
+          <datalist id="item_location_datalist_options">
+            <% @previous_item_locations.each do |location| %>
+              <option><%= location %></option>
             <% end %>
           </datalist>
         </div>

--- a/db/migrate/20210909165611_add_display_location_to_lists.rb
+++ b/db/migrate/20210909165611_add_display_location_to_lists.rb
@@ -1,0 +1,5 @@
+class AddDisplayLocationToLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :lists, :display_location, :boolean, default: false
+  end
+end

--- a/db/migrate/20210909171234_rename_department_to_location_for_items.rb
+++ b/db/migrate/20210909171234_rename_department_to_location_for_items.rb
@@ -1,0 +1,5 @@
+class RenameDepartmentToLocationForItems < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :items, :department, :location
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_24_004150) do
+ActiveRecord::Schema.define(version: 2021_09_09_165611) do
 
   create_table "items", force: :cascade do |t|
     t.integer "list_id", null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2021_08_24_004150) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "display_location", default: false
     t.index ["user_id"], name: "index_lists_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_09_165611) do
+ActiveRecord::Schema.define(version: 2021_09_09_171234) do
 
   create_table "items", force: :cascade do |t|
     t.integer "list_id", null: false
     t.string "name"
     t.string "person"
-    t.string "department"
+    t.string "location"
     t.boolean "bought", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/test/controllers/lists_controller_test.rb
+++ b/test/controllers/lists_controller_test.rb
@@ -96,7 +96,7 @@ class ListsControllerTest < ActionDispatch::IntegrationTest
       list_id: 1,
       name: "item",
       person: "person",
-      department: "department",
+      location: "location",
       bought: true,
       quantity: 0
     )

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -4,12 +4,12 @@ one:
   list: one
   name: MyString
   person: MyString
-  department: MyString
+  location: MyString
   bought: false
 
 two:
   list: two
   name: MyString
   person: MyString
-  department: MyString
+  location: MyString
   bought: false

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ItemTest < ActiveSupport::TestCase
   test "valid item can not have quantity less than zero" do
     list = List.new(name: "Shopping Place")
-    item = Item.new(name: "Bananas", person: "Me", department: "Produce", quantity: -1, list: list)
+    item = Item.new(name: "Bananas", person: "Me", location: "Produce", quantity: -1, list: list)
     refute item.valid?
     assert_includes item.errors[:quantity], "must be greater than or equal to 0"
   end

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -62,6 +62,7 @@ class ListTest < ActiveSupport::TestCase
         "name"=>"Shopping Place",
         "created_at"=>list.created_at,
         "updated_at"=>list.updated_at,
+        "display_location"=>false,
       },
       list.as_json
     )
@@ -74,12 +75,12 @@ class ListTest < ActiveSupport::TestCase
     list.items.create(
       name: "Item 1",
       person: "Person 1",
-      department: "Department 1"
+      location: "Location 1"
     ).save
     list.items.create(
       name: "Item 2",
       person: "Person 2",
-      department: "Department 2"
+      location: "Location 2"
     ).save
     assert_equal(
       {
@@ -88,6 +89,7 @@ class ListTest < ActiveSupport::TestCase
         "name"=>"Shopping Place",
         "created_at"=>list.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
         "updated_at"=>list.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
+        "display_location"=>false,
       },
       list.as_json
     )

--- a/test/system/items_test.rb
+++ b/test/system/items_test.rb
@@ -8,9 +8,9 @@ class ItemsTest < ApplicationSystemTestCase
 
   def create_previous_shopping_list! user
     previous_list = user.lists.create(name: "Aldi")
-    previous_list.items.create(name: "Bananas", person: "Brian", department: "Produce")
-    previous_list.items.create(name: "Apples", person: "Myk", department: "Produce")
-    previous_list.items.create(name: "Beer", person: "Brian", department: "Alcohol")
+    previous_list.items.create(name: "Bananas", person: "Brian", location: "Produce")
+    previous_list.items.create(name: "Apples", person: "Myk", location: "Produce")
+    previous_list.items.create(name: "Beer", person: "Brian", location: "Alcohol")
   end
 
   test "logged in user can add an item to a list" do
@@ -20,7 +20,7 @@ class ItemsTest < ApplicationSystemTestCase
     visit list_path(list)
     fill_in("Item name:", with: "Bananas")
     fill_in("Person:", with: "Brian")
-    fill_in("Department:", with: "Produce")
+    fill_in("Location:", with: "Produce")
     click_on "Add Item"
     assert_selector ".items-table-item", count: 1
     within ".items-table-item" do
@@ -35,7 +35,7 @@ class ItemsTest < ApplicationSystemTestCase
     visit list_path(list)
     fill_in("Item name:", with: "")
     fill_in("Person:", with: "Brian")
-    fill_in("Department:", with: "Produce")
+    fill_in("Location:", with: "Produce")
     click_on "Add Item"
     assert_selector ".the-list .list-item", count: 0
   end
@@ -63,15 +63,15 @@ class ItemsTest < ApplicationSystemTestCase
     assert_selector "#item_person_datalist_options option", text: "Myk", visible: false
   end
 
-  test "logged in user populates department name suggestions from previous list" do
+  test "logged in user populates location name suggestions from previous list" do
     login!
     user = User.find_by(uid: "31415")
     create_previous_shopping_list! user
     list = user.lists.create(name: "Shopping Place")
     visit list_path(list)
-    assert_selector "#item_department_datalist_options option", count: 2, visible: false
-    assert_selector "#item_department_datalist_options option", text: "Produce", visible: false
-    assert_selector "#item_department_datalist_options option", text: "Alcohol", visible: false
+    assert_selector "#item_location_datalist_options option", count: 2, visible: false
+    assert_selector "#item_location_datalist_options option", text: "Produce", visible: false
+    assert_selector "#item_location_datalist_options option", text: "Alcohol", visible: false
   end
 
   test "logged in user cannot add item when name finds a case insensitive match" do
@@ -82,9 +82,9 @@ class ItemsTest < ApplicationSystemTestCase
     visit list_path(list)
     fill_in("Item name:", with: "BaNaNas")
     fill_in("Person:", with: "Brian")
-    fill_in("Department:", with: "Produce")
-    assert_selector "#item_department_datalist_options option", count: 2, visible: false
-    assert_selector "#item_department_datalist_options option", text: "Produce", visible: false
-    assert_selector "#item_department_datalist_options option", text: "Alcohol", visible: false
+    fill_in("Location:", with: "Produce")
+    assert_selector "#item_location_datalist_options option", count: 2, visible: false
+    assert_selector "#item_location_datalist_options option", text: "Produce", visible: false
+    assert_selector "#item_location_datalist_options option", text: "Alcohol", visible: false
   end
 end

--- a/test/system/lists_test.rb
+++ b/test/system/lists_test.rb
@@ -29,7 +29,7 @@ class ListsTest < ApplicationSystemTestCase
     login!
     user = User.last
     list = user.lists.create(name: "Shopping Place")
-    list.items.create(name: "Bananas", person: "Person", department: "Produce")
+    list.items.create(name: "Bananas", person: "Person", location: "Produce")
     visit root_path
     assert_selector ".items-table-item", count: 1
     assert_css ".list-group-item .list-name", text: "Shopping Place"
@@ -42,7 +42,7 @@ class ListsTest < ApplicationSystemTestCase
     login!
     user = User.last
     list = user.lists.create(name: "Shopping Place")
-    list.items.create(name: "Bananas", person: "Person", department: "Produce")
+    list.items.create(name: "Bananas", person: "Person", location: "Produce")
     visit root_path
     assert_selector ".shopping-list", count: 1
     click_link("edit-list-#{list.id}")
@@ -52,7 +52,7 @@ class ListsTest < ApplicationSystemTestCase
     login!
     user = User.last
     list = user.lists.create(name: "Shopping Place")
-    list.items.create(name: "Bananas", person: "Person", department: "Produce")
+    list.items.create(name: "Bananas", person: "Person", location: "Produce")
     visit root_path
     assert_selector ".items-table-item", count: 1
     click_link("edit-list-#{list.id}")


### PR DESCRIPTION
### Add `display_location` boolean to `List` model
- Generate migration to add the column `display_location` to the `List` model. A boolean that determines if the "Location" column in the items table is displayed.
- Update naming convention when referencing the OLD "Department" column to the now NEW "Location" column.